### PR TITLE
Adding in Energy Corrections and Weights

### DIFF
--- a/plugins/Nm1Selector.cc
+++ b/plugins/Nm1Selector.cc
@@ -91,13 +91,13 @@ void Nm1Selector<T>::produce(edm::Event & event, const edm::EventSetup & setup) 
 	if (maskedCutFlowData.cutFlowPassed())
 	  pass = true;
 	//
-	std::cout << pass << std::endl;
+	//std::cout << pass << std::endl;
 	int ncuts = maskedCutFlowData.cutFlowSize();
 	for(int icut = 0; icut<ncuts; icut++) {
-	  std::cout << icut << " " << maskedCutFlowData.getNameAtIndex(icut).c_str() 
-		    << (int)maskedCutFlowData.isCutMasked(icut) << " " 
-		    << maskedCutFlowData.getValueCutUpon(icut) << " " 
-		    << (int)maskedCutFlowData.getCutResultByIndex(icut) << std::endl;
+	//  std::cout << icut << " " << maskedCutFlowData.getNameAtIndex(icut).c_str() 
+	//	    << (int)maskedCutFlowData.isCutMasked(icut) << " " 
+		//    << maskedCutFlowData.getValueCutUpon(icut) << " " 
+	//	    << (int)maskedCutFlowData.getCutResultByIndex(icut) << std::endl;
 	}
 	//
       } else {

--- a/python/TnPTreeProducer_cfg_UL17data.py
+++ b/python/TnPTreeProducer_cfg_UL17data.py
@@ -230,7 +230,7 @@ process.MessageLogger.cerr.threshold = ''
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.source = cms.Source("PoolSource",
-                            fileNames = options['INPUT_FILE_NAME'],
+                            fileNames = cms.untracked.vstring(varOptions.inputFiles)#options['INPUT_FILE_NAME'],
                             )
 process.maxEvents = cms.untracked.PSet( input = options['MAXEVENTS'])
 #process.maxEvents = cms.untracked.PSet(
@@ -475,7 +475,7 @@ if not options['useAOD'] :
 
 # Add SUSY variables to the "variables", add SUSY IDs to the "flags"
 if options['addSUSY'] :
-    setattr( process.tnpEleIDs.variables , 'el_miniIsoChg', cms.string("userFloat('miniIsoChg')") )
+    setattr( process.tnpEleIDs.variables , 'el_miniIsoChg', cms.string("('miniIsoChg')") )
     setattr( process.tnpEleIDs.variables , 'el_miniIsoAll', cms.string("userFloat('miniIsoAll')") )
     setattr( process.tnpEleIDs.variables , 'el_ptRatio', cms.string("userFloat('ptRatio')") )
     setattr( process.tnpEleIDs.variables , 'el_ptRatioUncorr', cms.string("userFloat('ptRatioUncorr')") )
@@ -528,7 +528,6 @@ process.p = cms.Path(
         )
 
 #print (" --- process.p successful")
-
 process.TFileService = cms.Service(
     "TFileService", fileName = cms.string(options['OUTPUT_FILE_NAME']),
     closeFileFast = cms.untracked.bool(True)

--- a/python/TnPTreeProducer_cfg_UL17mc.py
+++ b/python/TnPTreeProducer_cfg_UL17mc.py
@@ -174,7 +174,7 @@ options['TnPHLTTagFilters']    = cms.vstring("hltEle32L1DoubleEGWPTightGsfTrackI
 #options['TnPHLTTagFilters']    = cms.vstring("hltEle32WPTightGsfTrackIsoFilter")
 
 options['TnPHLTProbeFilters']  = cms.vstring()
-options['HLTFILTERTOMEASURE']  = cms.vstring("hltEle32WPTightGsfTrackIsoFilter")
+options['HLTFILTERTOMEASURE']  = cms.vstring("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEGL1SingleEGOrFilter")
 
 ###options['GLOBALTAG']           = 'auto:run2_data'
 
@@ -230,7 +230,7 @@ process.MessageLogger.cerr.threshold = ''
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.source = cms.Source("PoolSource",
-                            fileNames = options['INPUT_FILE_NAME'],
+                            fileNames = cms.untracked.vstring(varOptions.inputFiles)# options['INPUT_FILE_NAME'],
                             )
 process.maxEvents = cms.untracked.PSet( input = options['MAXEVENTS'])
 #process.maxEvents = cms.untracked.PSet(

--- a/python/egmTreesContent_cff.py
+++ b/python/egmTreesContent_cff.py
@@ -125,6 +125,14 @@ EleProbeVariablesToStore = cms.PSet(
     el_eelepout       = cms.string("eEleClusterOverPout()"),
     el_IoEmIop        = cms.InputTag("eleVarHelper:ioemiop"),
 
+    # energy correction 
+    el_ecalEnergyPostCorr   = cms.string("userFloat('ecalEnergyPostCorr')"),
+    el_ecalTrkEnergyPostCorr = cms.string("userFloat('ecalTrkEnergyPostCorr')"),
+    el_energyScaleUp   = cms.string("userFloat('energyScaleUp')"),
+    el_energyScaleDn = cms.string("userFloat('energyScaleDown')"),
+    el_energySigmaUp   = cms.string("userFloat('energySigmaUp')"),
+    el_energySigmaDn = cms.string("userFloat('energySigmaDown')"),
+
     )
 
 #print ("just before PhoProbeVariablesToStore in egmTreesContent")
@@ -192,7 +200,19 @@ TagVariablesToStore = cms.PSet(
     Ele_IsoMVA94X   = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV1Values"),
     Ele_noIsoMVA94XV2   = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV2Values"), 
     Ele_IsoMVA94XV2   = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV2Values"),
+    # energy correction 
+    Ele_ecalEnergyPostCorr   = cms.string("userFloat('ecalEnergyPostCorr')"),
+    Ele_ecalTrkEnergyPostCorr = cms.string("userFloat('ecalTrkEnergyPostCorr')"),
+    Ele_energyScaleUp   = cms.string("userFloat('energyScaleUp')"),
+    Ele_energyScaleDn = cms.string("userFloat('energyScaleDown')"),
+    Ele_energySigmaUp   = cms.string("userFloat('energySigmaUp')"),
+    Ele_energySigmaDn = cms.string("userFloat('energySigmaDown')"),
 
+    #other useful tag things
+    Ele_ecalEnergy    = cms.string("ecalEnergy()"),
+    Ele_5x5_r9        = cms.string("full5x5_showerShape().r9"),
+    Ele_r9            = cms.string("showerShape().r9"),
+    Ele_ecalDriven    = cms.string("ecalDrivenSeed"),
     )
 
 CommonStuffForGsfElectronProbe = cms.PSet(

--- a/python/egmTreesSetup_cff.py
+++ b/python/egmTreesSetup_cff.py
@@ -103,7 +103,7 @@ def setTagsProbes(process, options):
     
         
     ########################### TnP pairs ############################
-    masscut = cms.string("70<mass<110")         
+    masscut = cms.string("50<mass<130")         
     process.tnpPairingEleHLT   = cms.EDProducer("CandViewShallowCloneCombiner",
                                         decay = cms.string("tagEle@+ probeEle@-"), 
                                         checkCharge = cms.bool(True),


### PR DESCRIPTION
This PR:

adds in energy correction variables for both tag & probe 
adds in r9 and 5x5 r9 for tag
adds sum weight tree
relaxes mass cut to 50-130 (so we have room to apply the scale and smearings)
allows inputfile to be specified on the cmd line

So if you just merge this, then this should work, just do a test though. You should see the new tree created with the sum of the weights and the you should also see the new energy variables (which we have to apply manually)